### PR TITLE
Update uploadhandler.py line 168

### DIFF
--- a/django/core/files/uploadhandler.py
+++ b/django/core/files/uploadhandler.py
@@ -166,7 +166,7 @@ class MemoryFileUploadHandler(FileUploadHandler):
         """
         # Check the content-length header to see if we should
         # If the post is too large, we cannot use the Memory handler.
-        if content_length > settings.FILE_UPLOAD_MAX_MEMORY_SIZE:
+        if content_length > int(settings.FILE_UPLOAD_MAX_MEMORY_SIZE):
             self.activated = False
         else:
             self.activated = True


### PR DESCRIPTION
the variable content_length is an int and settings.FILE_UPLOAD_MAX_MEMORY_SIZE is a string. I verified this by using the python type() call. Wrapping the string variable in int(string)  fixes this issue.
